### PR TITLE
add options for latest and maxItems

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,18 @@ const products = store.addContentType({
 })
 ```
 
+#### latest
+- Type: `boolean` *optional*
+
+If `true`, sorts your RSS file with newest items at the top.
+
+#### maxItems
+- Type: `number` *optional*
+
+Limits the amount of items included in your RSS feed.
+
+**NOTE**: Should be used with `latest` set to  `true`, otherwise newer items will be excluded.
+
 #### feedOptions
 - Type `object` *required*
 
@@ -60,7 +72,7 @@ The top level options for your RSS feed. See [dylang/node-rss#feedoptions](https
 - Arg `node`
 - Returns `object`
 
-The item level options for your RSS feed. 
+The item level options for your RSS feed.
 For each option (see [dylang/node-rss#itemoptions](https://github.com/dylang/node-rss#itemoptions) for all options), `node` is the object that you passed into [Collection.addNode](https://gridsome.org/docs/data-store-api#collectionaddnodeoptions)
 
 **NOTE**: Since Gridsome will convert any `node` field into camelCase, make sure that any property you access on `node` is also camelCased.

--- a/index.js
+++ b/index.js
@@ -7,7 +7,13 @@ module.exports = function (api, options) {
     const feed = new RSS(options.feedOptions)
     const { collection } = store.getContentType(options.contentTypeName)
 
-    collection.data.forEach(item => {
+    let collectionData = options.latest ? [...collection.data].reverse() : [...collection.data]
+
+    if (options.maxItems) {
+      collectionData = collectionData.filter((item, index) => index < options.maxItems)
+    }
+
+    collectionData.forEach(item => {
       feed.item(options.feedItemOptions(item))
     })
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gridsome-plugin-rss",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Generate an RSS feed from your Gridsome data store",
   "homepage": "https://github.com/darthmeme/gridsome-plugin-rss/tree/master",
   "repository": "https://github.com/darthmeme/gridsome-plugin-rss/tree/master/#readme",


### PR DESCRIPTION
I added a few lines of code that would allow sorting the RSS feed with newest items listed first, as well as an option to limit the amount of items to include in the feed.

This was in reference to this issue: [https://github.com/darthmeme/gridsome-plugin-rss/issues/6](https://github.com/darthmeme/gridsome-plugin-rss/issues/6)

I also updated README.md to reflect the changes.