### PR TITLE
Sort nodes based on `date` values

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ const products = store.addContentType({
 
 If `true`, sorts your RSS file with newest items at the top.
 
-**NOTE**: In order to sort chronologically, nodes must have a valid `date` property. `date` must be a timestamp string or unix timestamp (integer). See [JS Date Object Parameters on MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date#Parameters) for details.
+**NOTE**: In order to sort chronologically, all nodes passed to this plugin must have a valid `date` property. `date` must be a timestamp string or unix timestamp (integer). If all nodes do not have valid dates, RSS items will **NOT** be sorted. See [JS Date Object Parameters on MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date#Parameters) for details.
 
 #### maxItems
 - Type: `number` *optional*

--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ const products = store.addContentType({
 
 If `true`, sorts your RSS file with newest items at the top.
 
+**NOTE**: In order to sort chronologically, nodes must have a valid `date` property. `date` must be a timestamp string or unix timestamp (integer). See [JS Date Object Parameters on MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date#Parameters) for details.
+
 #### maxItems
 - Type: `number` *optional*
 

--- a/index.js
+++ b/index.js
@@ -7,7 +7,17 @@ module.exports = function (api, options) {
     const feed = new RSS(options.feedOptions)
     const { collection } = store.getContentType(options.contentTypeName)
 
-    let collectionData = options.latest ? [...collection.data].reverse() : [...collection.data]
+    let collectionData = [...collection.data]
+
+    const collectionWithValidDates = collectionData.filter(node => !isNaN(new Date(node.date).getTime()))
+    if (collectionWithValidDates.length === collectionData.length)
+      collectionData.sort((nodeA, nodeB) => {
+        if (options.latest) {
+          return new Date(nodeB.date).getTime() - new Date(nodeA.date).getTime()
+        } else {
+          return new Date(nodeA.date).getTime() - new Date(nodeB.date).getTime()
+        }
+      })
 
     if (options.maxItems) {
       collectionData = collectionData.filter((item, index) => index < options.maxItems)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gridsome-plugin-rss",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Generate an RSS feed from your Gridsome data store",
   "homepage": "https://github.com/darthmeme/gridsome-plugin-rss/tree/master",
   "repository": "https://github.com/darthmeme/gridsome-plugin-rss/tree/master/#readme",


### PR DESCRIPTION
Regarding [https://github.com/darthmeme/gridsome-plugin-rss/pull/7](https://github.com/darthmeme/gridsome-plugin-rss/pull/7),

It appears Gridsome does not internally assign dates nor sort nodes during the build step. So I made changes to check to see if nodes all have valid date, then sort chronologically based on the latest option.

Apologies for not catching this sooner and including it in my original PR. I thought gridsome was sorting its data layer under the hood. I also made sure not to break any previous functionality for the plugin. Sorting will be skipped if dates are invalid or not provided.