### PR TITLE
Allows `dateField` to be passed as an option

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,12 @@ If `true`, sorts your RSS file with newest items at the top.
 
 **NOTE**: In order to sort chronologically, all nodes passed to this plugin must have a valid `date` property. `date` must be a timestamp string or unix timestamp (integer). If all nodes do not have valid dates, RSS items will **NOT** be sorted. See [JS Date Object Parameters on MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date#Parameters) for details.
 
+#### dateField
+- Type: `string` *optional*
+- Default: 'date'
+
+If set, it will sort your items chonologically by the date field you set.
+
 #### maxItems
 - Type: `number` *optional*
 

--- a/index.js
+++ b/index.js
@@ -6,16 +6,17 @@ module.exports = function (api, options) {
   api.beforeBuild(({ store }) => {
     const feed = new RSS(options.feedOptions)
     const { collection } = store.getContentType(options.contentTypeName)
+    const dateField = options.dateField || 'date'
 
     let collectionData = [...collection.data]
 
-    const collectionWithValidDates = collectionData.filter(node => !isNaN(new Date(node.date).getTime()))
+    const collectionWithValidDates = collectionData.filter(node => !isNaN(new Date(node[dateField]).getTime()))
     if (collectionWithValidDates.length === collectionData.length)
       collectionData.sort((nodeA, nodeB) => {
         if (options.latest) {
-          return new Date(nodeB.date).getTime() - new Date(nodeA.date).getTime()
+          return new Date(nodeB[dateField]).getTime() - new Date(nodeA[dateField]).getTime()
         } else {
-          return new Date(nodeA.date).getTime() - new Date(nodeB.date).getTime()
+          return new Date(nodeA[dateField]).getTime() - new Date(nodeB[dateField]).getTime()
         }
       })
 


### PR DESCRIPTION
My posts weren't sorting correctly so after digging into it  realised it's because they didn't have a `date` field. I was generating them a little more granularly with `createdAt`, `publishedAt`, and `updatedAt`.

I added a `dateField` option to the config so I could pass in `publishedDate` instead of relying on the default `date` to sort the posts by.