### PR TITLE
Moving the build hook to "afterBuild" and updating default output dir to "dist"

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ module.exports = {
           author: node.fields.author
         }),
         output: {
-          dir: './static',
+          dir: './dist',
           name: 'rss.xml'
         }
       }
@@ -111,19 +111,20 @@ feedItemOptions: node => ({
 #### output
 - Type `object` *optional*
 - Defaults:
-  - `dir`: `./static`
+  - `dir`: `./dist`
   - `name`: `rss.xml`
 
 Specify the output directory and filename of the generated RSS.
+By default, it is your configured build output directory (the configured value for key `outputDir`) or just `./dist`
 
-`dir` - a relative path to desired output directory
+`dir` - a relative path to desired output directory.
 
 `name` - the filename of your XML file. You can omit the extension if you want to.
 
 Example:
 ```js
 output: {
-  dir: './static/',
+  dir: './dist/',
   name: 'rss' // or rss.xml
 }
 ```

--- a/index.js
+++ b/index.js
@@ -3,7 +3,8 @@ const fs = require('fs')
 const path = require('path')
 
 module.exports = function (api, options) {
-  api.beforeBuild(({ store }) => {
+  api.afterBuild(({ config }) => {
+    const store = api.store
     const feed = new RSS(options.feedOptions)
     const { collection } = store.getContentType(options.contentTypeName)
     const dateField = options.dateField || 'date'
@@ -11,7 +12,7 @@ module.exports = function (api, options) {
     let collectionData = [...collection.data]
 
     const collectionWithValidDates = collectionData.filter(node => !isNaN(new Date(node[dateField]).getTime()))
-    if (collectionWithValidDates.length === collectionData.length)
+    if (collectionWithValidDates.length === collectionData.length) {
       collectionData.sort((nodeA, nodeB) => {
         if (options.latest) {
           return new Date(nodeB[dateField]).getTime() - new Date(nodeA[dateField]).getTime()
@@ -19,6 +20,7 @@ module.exports = function (api, options) {
           return new Date(nodeA[dateField]).getTime() - new Date(nodeB[dateField]).getTime()
         }
       })
+    }
 
     if (options.maxItems) {
       collectionData = collectionData.filter((item, index) => index < options.maxItems)
@@ -29,7 +31,7 @@ module.exports = function (api, options) {
     })
 
     const output = {
-      dir: './static',
+      dir: config.outputDir || './dist',
       name: 'rss.xml',
       ...options.output
     }
@@ -40,11 +42,9 @@ module.exports = function (api, options) {
       ? output.name
       : `${output.name}.xml`
 
-    if (outputPathExists) {
-      fs.writeFileSync(path.resolve(process.cwd(), output.dir, fileName), feed.xml())
-    } else {
+    if (!outputPathExists) {
       fs.mkdirSync(outputPath)
-      fs.writeFileSync(path.resolve(process.cwd(), output.dir, fileName), feed.xml())
     }
+    fs.writeFileSync(path.resolve(process.cwd(), output.dir, fileName), feed.xml())
   })
 }


### PR DESCRIPTION
Right now, the rss feed by default is generated in the `static` dir.
The static dir is one of the directories where we have checked-in files and we do not want build-generated files to fall in there too (then git too marks it as a new file ready for check-in; which we dont want).
Of course there is the option of configuring the output dir, but since the hook is `beforeBuild` even if we configure the `dist` dir to be the output it won't work - because, this plugin will be the first to create the `dist` dir and it will be deleted+re-created by the build processes (fresh distribution files has to be created on `gridsome build`, so) there by making it feel that the rss.xml was never generated at all.

So, I moved the hook to `afterBuild` and made the `dist` dir (or whatever is configured by the user as the build output dir) as the default outputDir.