### PR TITLE
Fixed issue with loadSource which was causing build break

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,8 @@ module.exports = function (api, options) {
   let articleData = []
   api.loadSource(store => {
     let { collection } = store.getCollection(options.contentTypeName)
-    this.articleData = [...collection.data]
+    if (collection)
+      this.articleData = [...collection.data]
   })
 
   api.afterBuild(({ config }) => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gridsome-plugin-rss",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "Generate an RSS feed from your Gridsome data store",
   "homepage": "https://github.com/darthmeme/gridsome-plugin-rss/tree/master",
   "repository": "https://github.com/darthmeme/gridsome-plugin-rss/tree/master/#readme",


### PR DESCRIPTION
This will be called before the store is initialized which will result in `collection` to be `undefined` and finally it will fail build process. At least for sanity, add condition to check if collection exist so that it will not end up with follow error:

`Cannot destructure property 'collection' of 'store.getCollection(...)' as it is undefined`.

For another issues which will be caused by blank array for data, you will need to call this function inside `beforeBuild` event so that data is available there.